### PR TITLE
Fix contex-menu in non-editeara

### DIFF
--- a/menus/context.cson
+++ b/menus/context.cson
@@ -3,5 +3,5 @@
 ###
 
 'context-menu':
-  '.workspace':
+  '.workspace .editor:not(.mini)':
     'Toggle CoffeeScript Preview': 'coffeescript-preview:toggle'


### PR DESCRIPTION
The context-menu `Toggle CoffeeScript Preview` also in tool-panel.
So, add selector `.editor:not(.mini)`, let context-menu only appear in edit-area.

Before:
![before](https://cloud.githubusercontent.com/assets/1926185/3793236/73026192-1b90-11e4-9c1c-b0e499727f12.png)
